### PR TITLE
Add nancodes util

### DIFF
--- a/src/nancodes.py
+++ b/src/nancodes.py
@@ -1,0 +1,19 @@
+"""Provides unified not-a-number codes for the indicators.
+
+Currently requires a manual sync between the covidcast-indicators
+and the utils repos.
+* in cmu-delphi/covidcast-indicators: _delphi_utils_python/delphi_utils/
+* in cmu-delphi/utils: src/
+"""
+
+from enum import IntEnum
+
+class Nans(IntEnum):
+    """An enum of not-a-number codes for the indicators."""
+
+    NOT_MISSING = 0
+    NOT_APPLICABLE = 1
+    REGION_EXCEPTION = 2
+    DATA_INSUFFICIENT = 3
+    PRIVACY = 4
+    UNKNOWN = 5


### PR DESCRIPTION
This work is part of [this PR](https://github.com/cmu-delphi/delphi-epidata/pull/417). Adds a clone of the nancodes util present in covidcast-indicators for use in the database acquisition code. The purpose of this util is to provide a centralized set of nancodes across the codebase. For the time being, this clone will need to be manually synced with changes in covidcast-indicators and vice versa. 